### PR TITLE
Update to CCF Specification 1.0

### DIFF
--- a/.github/workflows/cddl.yml
+++ b/.github/workflows/cddl.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   CCF_SPECS_DOCUMENT: ccf_specs.md

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -1,9 +1,8 @@
 # Cadence Compact Format (CCF)
 
 Author: Faye Amacker  
-Status: RC3  
-Date: September 4, 2023  
-Revision: 20230904a
+Version: 1.0.0  
+Date: October 22, 2024  
 
 ## Abstract
 
@@ -15,13 +14,9 @@ CCF defines "Deterministic CCF Encoding Requirements" and makes it optional. CCF
 
 CCF obsoletes [JSON-Cadence Data Interchange Format](https://developers.flow.com/cadence/json-cadence-spec) (JSON-CDC) for use cases that do not require JSON.
 
-## Status of this Document
-
-This document is a release candidate (RC3).
-
 ## Copyright Notice
 
-Copyright (c) 2022-2023 Dapper Labs, Inc. and the persons identified as the document authors.
+Copyright © 2022-2024 Flow Foundation and the persons identified as the document authors.
 
 This document is licensed under the terms of the Apache License, Version 2.0. See [LICENSE](LICENSE) for more information.
 
@@ -29,7 +24,9 @@ This document is licensed under the terms of the Apache License, Version 2.0. Se
 
 This document specifies Cadence Compact Format.
 
-It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g. events).
+Some requirements defined in this document are explicitly specified as optional.  
+
+It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g. events).  For example, CCF-based formats or protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements".
 
 ## Introduction
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -1035,7 +1035,7 @@ array-value = [* value]
 
 dict-value = [* (key: value, value: value)]
 
-; composite-value is used to encode struct, contract, enum, event, and resource.
+; composite-value is used to encode struct, contract, enum, event, resource, and attachment.
 composite-value = [* (field: value)]
 
 path-value = [

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -28,6 +28,8 @@ Some requirements defined in this document are explicitly specified as optional.
 
 It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g. events).  For example, CCF-based formats or protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements".
 
+It is outside the scope of this document to specify encoding of version numbers for CCF itself, CCF-based formats, or CCF-based protocols.  For example, CCF-based formats and protocols are free to specify an encoding that uses SemVer, sequence-based versioning, other versioning, or no versioning.  Some CCF-based formats or protocols may want to specify using CBOR Sequences ([IETF RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) encoded in CCF.
+
 ## Introduction
 
 CCF is a data format that allows compact, efficient, and deterministic encoding of Cadence external values.

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -674,7 +674,8 @@ cbor-tag-dict-type = 141
 cbor-tag-reference-type = 142
 cbor-tag-intersection-type = 143
 cbor-tag-capability-type = 144
-; 145-159 are reserved
+cbor-tag-inclusiverange-type = 145
+; 146-159 are reserved
 
 ; composite types
 cbor-tag-struct-type = 160
@@ -704,7 +705,8 @@ cbor-tag-reference-type-value = 190
 cbor-tag-intersection-type-value = 191
 cbor-tag-capability-type-value = 192
 cbor-tag-function-type-value = 193
-; 194-207 are reserved
+cbor-tag-inclusiverange-type-value = 194
+; 195-207 are reserved
 
 ; composite type values
 cbor-tag-struct-type-value = 208
@@ -818,6 +820,7 @@ inline-type =
     / reference-type
     / intersection-type
     / capability-type
+    / inclusiverange-type
     / type-ref
 
 simple-type =
@@ -866,6 +869,10 @@ capability-type =
         ; borrow-type
         inline-type / nil
     ])
+
+inclusiverange-type =
+    ; cbor-tag-inclusiverange-type
+    #6.145(inline-type)
 
 type-ref =
     ; cbor-tag-type-ref
@@ -956,6 +963,7 @@ value =
     / composite-value
     / path-value
     / capability-value
+    / inclusiverange-value
     / function-value
     / type-value
 
@@ -985,6 +993,12 @@ path-capability-value = [
 id-capability-value = [
     address: address-value,
     id: uint64-value
+]
+
+inclusiverange-value = [
+    start: value,
+    end: value,
+    step: value,
 ]
 
 simple-value =
@@ -1080,6 +1094,7 @@ type-value = simple-type-value
     / reference-type-value
     / intersection-type-value
     / capability-type-value
+    / inclusiverange-type-value
     / type-value-ref
 
 simple-type-value =
@@ -1190,6 +1205,10 @@ capability-type-value =
       ; borrow-type
       type-value / nil
     ])
+
+inclusiverange-type-value =
+    ; cbor-tag-inclusiverange-type-value
+    #6.194(type-value)
 
 type-value-ref =
     ; cbor-tag-type-value-ref

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -867,7 +867,7 @@ reference-type =
 intersection-type =
     ; cbor-tag-intersection-type
     #6.143([
-      types: [+ inline-type]
+      types: [+ inline-type],
     ])
 
 capability-type =
@@ -875,7 +875,7 @@ capability-type =
     ; use an array as an extension point
     #6.144([
         ; borrow-type
-        inline-type / nil
+        inline-type / nil,
     ])
 
 inclusiverange-type =
@@ -893,7 +893,7 @@ entitlement-set-authorization-type =
 	; cbor-tag-entitlement-set-authorization-type
 	#6.146([
 	    kind: uint,
-	    entitlements: [+ tstr]
+	    entitlements: [+ tstr],
 	])
 
 entitlement-map-authorization-type =
@@ -935,14 +935,7 @@ simple-type-id = &(
     storage-path-type-id: 26,
     public-path-type-id: 27,
     private-path-type-id: 28,
-    auth-account-type-id: 29,
-    public-account-type-id: 30,
-    auth-account-keys-type-id: 31,
-    public-account-keys-type-id: 32,
-    auth-account-contracts-type-id: 33,
-    public-account-contracts-type-id: 34,
     deployed-contract-type-id: 35,
-    account-key-type-id: 36,
     block-type-id: 37,
     any-type-id: 38,
     any-struct-type-id: 39,
@@ -962,6 +955,49 @@ simple-type-id = &(
     word256-type-id: 53,
     any-struct-attachment-type-id: 54,
     any-resource-attachment-type-id: 55,
+    storage-capability-controller-type-id: 56,
+    account-capability-controller-type-id: 57,
+    account-type-id: 58,
+    account-contracts-type-id: 59,
+    account-keys-type-id: 60,
+    account-inbox-type-id: 61,
+    account-storage-capabilities-type-id: 62,
+    account-account-capabilities-type-id: 63,
+    account-capabilities-type-id: 64,
+    account-storage-type-id: 65,
+    mutate-type-id: 66,
+    insert-type-id: 67,
+    remove-type-id: 68,
+    identity-type-id: 69,
+    storage-type-id: 70,
+    save-value-type-id: 71,
+    load-value-type-id: 72,
+    copy-value-type-id: 73,
+    borrow-value-type-id: 74,
+    contracts-type-id: 75,
+    add-contract-type-id: 76,
+    update-contract-type-id: 77,
+    remove-contract-type-id: 78,
+    keys-type-id: 79,
+    add-key-type-id: 80,
+    revoke-key-type-id: 81,
+    inbox-type-id: 82,
+    publish-inbox-capability-type-id: 83,
+    unpublish-inbox-capability-type-id: 84,
+    claim-inbox-capability-type-id: 85,
+    capabilities-type-id: 86,
+    storage-capabilities-type-id: 87,
+    account-capabilities-type-id: 88,
+    publish-capability-type-id: 89,
+    unpublish-capability-type-id: 90,
+    get-storage-capability-controller-type-id: 91,
+    issue-storage-capability-controller-type-id: 92,
+    get-account-capability-controller-type-id: 93,
+    issue-account-capability-controller-type-id: 94,
+    capabilities-mapping-type-id: 95,
+    account-mapping-type-id: 96,
+    hashable-struct-type-id: 97,
+    fixedSize-unsigned-integer-type-id: 98,
 )
 
 ccf-typedef-and-value-message =

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,7 +2,7 @@
 
 Author: Faye Amacker  
 Version: 1.0.0  
-Date: January 26, 2025  
+Date: May 19, 2025
 
 ## Abstract
 
@@ -143,7 +143,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 This specification uses this subset of CBOR data items as defined in RFC 8949:
 - nil
 - bool
-- positive integer
+- unsigned integer
 - negative integer
 - byte string
 - text string
@@ -640,7 +640,7 @@ There are 3 top level CCF messages: `ccf-typedef-message`, `ccf-typedef-and-valu
 
 Cadence types are encoded as `inline-type` (inlined) or as `composite-typedef` (not inlined).
 
-Cadence data is encoded depending on its type. For example, Cadence `UInt8` is encoded as CBOR positive integer, Cadence `String` is encoded as CBOR text string, Cadence `Address` is encoded as CBOR byte string, and Cadence struct data is encoded as an array of its raw field data.
+Cadence data is encoded depending on its type. For example, Cadence `UInt8` is encoded as CBOR unsigned integer, Cadence `String` is encoded as CBOR text string, Cadence `Address` is encoded as CBOR byte string, and Cadence struct data is encoded as an array of its raw field data.
 
 ### Cadence Types and Type Values
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -682,7 +682,8 @@ cbor-tag-resource-type = 161
 cbor-tag-event-type = 162
 cbor-tag-contract-type = 163
 cbor-tag-enum-type = 164
-; 165-175 are reserved
+cbor-tag-attachment-type = 165
+; 166-175 are reserved
 
 ; interface types
 cbor-tag-struct-interface-type = 176
@@ -711,7 +712,8 @@ cbor-tag-resource-type-value = 209
 cbor-tag-event-type-value = 210
 cbor-tag-contract-type-value = 211
 cbor-tag-enum-type-value = 212
-; 213-223 are reserved
+cbor-tag-attachment-type-value = 213
+; 214-223 are reserved
 
 ; interface type values
 cbor-tag-struct-interface-type-value = 224
@@ -739,6 +741,7 @@ composite-typedef = [
         / contract-type
         / event-type
         / enum-type
+        / attachment-type
         / struct-interface-type
         / resource-interface-type
         / contract-interface-type
@@ -789,6 +792,10 @@ contract-type =
 enum-type =
     ; cbor-tag-enum-type
     #6.164(composite-type)
+
+attachment-type =
+    ; cbor-tag-attachment-type
+    #6.165(composite-type)
 
 struct-interface-type =
     ; cbor-tag-struct-interface-type
@@ -1066,6 +1073,7 @@ type-value = simple-type-value
     / contract-type-value
     / event-type-value
     / enum-type-value
+    / attachment-type-value
     / struct-interface-type-value
     / resource-interface-type-value
     / contract-interface-type-value
@@ -1120,6 +1128,10 @@ contract-type-value =
 enum-type-value =
     ; cbor-tag-enum-type-value
     #6.212(composite-type-value)
+
+attachment-type-value =
+    ; cbor-tag-attachment-type-value
+    #6.213(composite-type-value)
 
 struct-interface-type-value =
     ; cbor-tag-struct-interface-type-value

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -113,17 +113,6 @@ Other considerations for using CBOR include availability and quality of CBOR cod
 
 CBOR data can be exchanged between standards compliant CBOR codecs implemented in any programming language.
 
-CBOR-based formats and protocols can use existing CBOR codecs. For example, [CCF codec](https://github.com/onflow/cadence/tree/master/encoding/ccf) in Cadence uses [fxamacker/cbor](https://github.com/fxamacker/cbor):
-  - `fxamacker/cbor` was designed with security in mind and passed multiple security assessments in 2022. A [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) produced by NCC Group for Microsoft Corporation includes parts of fxamacker/cbor.
-  - `fxamacker/cbor` is used in projects by Arm Ltd., Cisco, EdgeX&nbsp;Foundry, Flow Foundation, Fraunhofer&#8209;AISEC, IBM, Kubernetes, Linux&nbsp;Foundation, Microsoft, Mozilla, Tailscale, Teleport, [and&nbsp;others](https://github.com/fxamacker/cbor#who-uses-fxamackercbor). Notably, it was already [used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
-  - `fxamacker/cbor` is maintained by the author of this document.
-
-CBOR codecs are available in various programming languages. Examples include:
-
-- __.NET Languages__: Microsoft maintains [System.Formats.Cbor](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor), the CBOR codec in .Net Platform Extensions.
-- __C/C++__: Intel maintains [TinyCBOR](https://github.com/intel/tinycbor), a CBOR codec optimized for very fast operation with very small footprint.
-- __Javascript__: Joe Hildebrand (former VP of Engineering at Mozilla) maintains [hildji/cbor2](https://github.com/hildjj/cbor2).
-
 Projects implementing a CCF codec should evaluate more than one CBOR codec for standards compliance, security, and other factors.
 
 ### Terminology

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,7 +2,7 @@
 
 Author: Faye Amacker  
 Version: 1.0.0  
-Date: May 19, 2025
+Date: May 20, 2025
 
 ## Abstract
 
@@ -28,7 +28,7 @@ Some requirements defined in this document are explicitly specified as optional.
 
 It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g. events).  For example, CCF-based formats or protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements".
 
-It is outside the scope of this document to specify encoding of version numbers for CCF itself, CCF-based formats, or CCF-based protocols.  For example, CCF-based formats and protocols are free to specify an encoding that uses SemVer, sequence-based versioning, other versioning, or no versioning.  Some CCF-based formats or protocols may want to specify using CBOR Sequences ([IETF RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) encoded in CCF.
+It is outside the scope of this document to specify encoding of version numbers for CCF itself, CCF-based formats, or CCF-based protocols.  For example, CCF-based formats and protocols are free to specify an encoding that uses SemVer, sequence-based versioning, other versioning, or no versioning.  Some CCF-based formats or protocols may want to specify using CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) encoded in CCF.
 
 ## Introduction
 
@@ -47,7 +47,7 @@ Some requirements (such as "Deterministic CCF Encoding Requirements") are define
 
 CCF uses CBOR and is designed to allow efficient detection and rejection of malformed messages without creating Cadence objects. This allows more costly checks for validity, etc. to be performed only on well-formed messages.
 
-CBOR is an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) defined by [IETF&nbsp;STD&nbsp;94](https://www.rfc-editor.org/info/std94). CBOR is designed to be relevant for decades and is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), C-DNS&nbsp;([IETF&nbsp;RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([IETF&nbsp;RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
+CBOR is a binary data format specified by [RFC 8949](https://www.rfc-editor.org/info/std94) and designated by IETF as an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) (STD&nbsp;94). CBOR is designed to be relevant for decades and is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
 
 ### Objectives
 
@@ -82,7 +82,9 @@ CCF is designed to support:
 
 ### Why CBOR
 
-CBOR is an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) defined by [IETF&nbsp;STD&nbsp;94 (RFC 8949)](https://www.rfc-editor.org/info/std94):
+CBOR is a binary data format specified by [RFC 8949](https://www.rfc-editor.org/info/std94) and designated by IETF as an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) (STD&nbsp;94).
+
+Design goals of CBOR balances tradeoffs, making it useful as a building block for new formats and protocols:
 
 > The Concise Binary Object Representation (CBOR) is a data format
    whose design goals include the possibility of extremely small code
@@ -90,7 +92,9 @@ CBOR is an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) defined b
    for version negotiation. These design goals make it different from
    earlier binary serializations such as ASN.1 and MessagePack.
 
-In addition to the aspects listed in CBOR's design goals, CBOR-based formats can support:
+CBOR is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
+
+Notably, CBOR-based data formats like CCF can be specified to support:
 - Deterministic encodings across programming languages. Encoders implemented in different languages can produce identical deterministic encodings.
 - Separate detection of malformed data and invalid data. Decoders can efficiently reject malformed inputs without creating Cadence objects.
 
@@ -103,9 +107,7 @@ Published comparisons between CBOR and other binary data formats such as Protoco
 - Appendix C of RFC 8618 Compacted-DNS: [Comparison of Binary Formats](https://www.rfc-editor.org/rfc/rfc8618#appendix-C)
 - Appendix E of RFC 8949 (STD 94) CBOR: [Comparison of Other Binary Formats to CBOR's Design Objectives](https://www.rfc-editor.org/rfc/rfc8949.html#name-comparison-of-other-binary-)
 
-CBOR is used in data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([IETF&nbsp;RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([IETF&nbsp;RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
-
-Although using a 100% custom data format can sometimes produce smaller encodings than CBOR, that alone doesn't outweigh the combination of other qualities and considerations such as security, maintainability, risks, etc.
+Although using a 100% custom data format can sometimes produce smaller encodings than CBOR, that alone doesn't outweigh the combination of other qualities and considerations such as maturity of specification, security, maintainability, risks, etc.
 
 Lastly, Cadence is [already using CBOR](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) to encode internal values, so using CBOR to encode external values added to the list of stronger reasons making CBOR a good fit.
 
@@ -116,6 +118,8 @@ Other considerations for using CBOR include availability and quality of CBOR cod
 CBOR data can be exchanged between standards compliant CBOR codecs implemented in any programming language.
 
 Projects implementing a CCF codec should evaluate more than one CBOR codec for standards compliance, security, and other factors.
+
+When evaluating and comparing codecs, benchmarks and tests should include decoding malicious data.
 
 ### Terminology
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -931,7 +931,7 @@ simple-type-id = &(
     fix64-type-id: 22,
     ufix64-type-id: 23,
     path-type-id: 24,
-    capability-path-type-id: 25,
+    capability-type-id: 25,
     storage-path-type-id: 26,
     public-path-type-id: 27,
     private-path-type-id: 28,
@@ -1043,16 +1043,7 @@ path-value = [
     identifier: tstr,
 ]
 
-capability-value = 
-    path-capability-value
-    / id-capability-value
-
-path-capability-value = [
-    address: address-value,
-    path: path-value,
-]
-
-id-capability-value = [
+capability-value = [
     address: address-value,
     id: uint64-value,
 ]

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,7 +2,7 @@
 
 Author: Faye Amacker  
 Version: 1.0.0  
-Date: May 20, 2025
+Date: March 27, 2025
 
 ## Abstract
 
@@ -28,7 +28,7 @@ Some requirements defined in this document are explicitly specified as optional.
 
 It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g., events).  For example, CCF-based formats or protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements."
 
-It is outside the scope of this document to specify the encoding of version numbers of CCF itself, CCF-based formats, or CCF-based protocols.  For example, CCF-based formats and protocols can specify an encoding that uses SemVer, sequence-based versioning, other versioning, or no versioning.  Some CCF-based formats or protocols may want to specify using CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) encoded in CCF.
+This document does not specify how to encode version numbers of CCF itself, CCF-based formats, or CCF-based protocols.  CCF-based formats and protocols can specify an encoding that uses CalVer, SemVer, sequence-based versioning, any other versioning, or no versioning.  Some CCF-based formats or protocols may want to use CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) encoded in CCF.
 
 ## Introduction
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -1053,6 +1053,7 @@ function-value = [
         ]
     ]
     return-type: type-value
+    purity: int
 ]
 
 type-value = simple-type-value

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -129,7 +129,7 @@ This specification also uses the following notations:
 
 #### Requirements Terminology
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [[RFC2119](https://www.rfc-editor.org/info/rfc2119)] [[RFC8174](https://www.rfc-editor.org/info/rfc8174)] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://www.rfc-editor.org/info/bcp14) [[RFC2119](https://www.rfc-editor.org/info/rfc2119)] [[RFC8174](https://www.rfc-editor.org/info/rfc8174)] when, and only when, they appear in all capitals, as shown here.
 
 #### CBOR Terminology
 
@@ -198,7 +198,7 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - CBOR data items MUST be well-formed and valid as defined in RFC 8949. For example, CBOR text strings MUST contain valid UTF-8. As an exception, RFC 8949 requirements for CBOR maps are not applicable because CCF does not use CBOR maps.
 
-- CCF encodings must comply with specifications in "CCF Specified in CDDL Notation" section of this document.
+- CCF encodings MUST comply with specifications in "CCF Specified in CDDL Notation" section of this document.
 
 - `composite-type.id` MUST be unique in `ccf-typedef-message` or `ccf-typedef-and-value-message`.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -109,8 +109,6 @@ Published comparisons between CBOR and other binary data formats such as Protoco
 
 Although using a 100% custom data format can sometimes produce smaller encodings than CBOR, that alone doesn't outweigh the combination of other qualities and considerations such as maturity of specification, security, maintainability, risks, etc.
 
-Lastly, Cadence is [already using CBOR](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) to encode internal values, so using CBOR to encode external values added to the list of stronger reasons making CBOR a good fit.
-
 Other considerations for using CBOR include availability and quality of CBOR codecs in various programming languages.
 
 ### Interoperability and Reuse of CBOR Codecs

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -892,13 +892,13 @@ unauthorized-type = nil
 entitlement-set-authorization-type =
 	; cbor-tag-entitlement-set-authorization-type
 	#6.146([
-	    kind: uint8,
-	    entitlements: [+ string]
+	    kind: uint,
+	    entitlements: [+ tstr]
 	])
 
 entitlement-map-authorization-type =
 	; cbor-tag-entitlement-map-authorization-type
-	#6.147(entitlement: string)
+	#6.147(tstr)
 
 type-ref =
     ; cbor-tag-type-ref
@@ -1246,13 +1246,13 @@ unauthorized-type-value = nil
 entitlement-set-authorization-type-value =
 	; cbor-tag-entitlement-set-authorization-type-value
 	#6.195([
-	    kind: uint8,
-	    entitlements: [+ string],
+	    kind: uint,
+	    entitlements: [+ tstr],
 	])
 
-entitlement-map-authorization-type =
+entitlement-map-authorization-type-value =
 	; cbor-tag-entitlement-map-authorization-type-value
-	#6.196(entitlement: string)
+	#6.196(tstr)
 
 type-value-ref =
     ; cbor-tag-type-value-ref

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -227,7 +227,7 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
   - `composite-type-value.initializers`
   - `function-value.parameters`
 
-- Elements MUST be unique in `restricted-type` or `restricted-type-value`.
+- Elements MUST be unique in `intersection-type` or `intersection-type-value`.
 
 - Keys MUST be unique in `dict-value`. Decoders are not always required to check for duplicate dictionary keys. In some cases, checking for duplicate dictionary key is not necessary or it may be delegated to the application.
 
@@ -258,8 +258,8 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
   - `dict-value` key-value pairs MUST be sorted by key.
   - `composite-type.fields` MUST be sorted by `name`
   - `composite-type-value.fields` MUST be sorted by `name`.
-  - `restricted-type.restrictions` MUST be sorted by restriction's `cadence-type-id`.
-  - `restricted-type-value.restrictions` MUST be sorted by restriction's `cadence-type-id`.
+  - `intersection-type.types` MUST be sorted by restriction's `cadence-type-id`.
+  - `intersection-type-value.types` MUST be sorted by restriction's `cadence-type-id`.
 
 ## Security Considerations
 
@@ -672,7 +672,7 @@ cbor-tag-varsized-array-type = 139
 cbor-tag-constsized-array-type = 140
 cbor-tag-dict-type = 141
 cbor-tag-reference-type = 142
-cbor-tag-restricted-type = 143
+cbor-tag-intersection-type = 143
 cbor-tag-capability-type = 144
 ; 145-159 are reserved
 
@@ -701,7 +701,7 @@ cbor-tag-varsized-array-type-value = 187
 cbor-tag-constsized-array-type-value = 188
 cbor-tag-dict-type-value = 189
 cbor-tag-reference-type-value = 190
-cbor-tag-restricted-type-value = 191
+cbor-tag-intersection-type-value = 191
 cbor-tag-capability-type-value = 192
 cbor-tag-function-type-value = 193
 ; 194-207 are reserved
@@ -816,7 +816,7 @@ inline-type =
     / constsized-array-type
     / dict-type
     / reference-type
-    / restricted-type
+    / intersection-type
     / capability-type
     / type-ref
 
@@ -853,11 +853,10 @@ reference-type =
       type: inline-type,
     ])
 
-restricted-type =
-    ; cbor-tag-restricted-type
+intersection-type =
+    ; cbor-tag-intersection-type
     #6.143([
-      type: inline-type / nil,
-      restrictions: [* inline-type]
+      types: [+ inline-type]
     ])
 
 capability-type =
@@ -1079,7 +1078,7 @@ type-value = simple-type-value
     / contract-interface-type-value
     / function-type-value
     / reference-type-value
-    / restricted-type-value
+    / intersection-type-value
     / capability-type-value
     / type-value-ref
 
@@ -1178,11 +1177,10 @@ reference-type-value =
       type: type-value,
     ])
 
-restricted-type-value =
-    ; cbor-tag-restricted-type-value
+intersection-type-value =
+    ; cbor-tag-intersection-type-value
     #6.191([
-      type: type-value / nil,
-      restrictions: [* type-value]
+      types: [+ type-value]
     ])
 
 capability-type-value =

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,7 +2,7 @@
 
 Author: Faye Amacker  
 Version: 1.0.0  
-Date: March 30, 2025
+Date: March 31, 2025
 
 ## Abstract
 
@@ -26,9 +26,9 @@ This document specifies Cadence Compact Format.
 
 This document explicitly specifies some requirements as optional. 
 
-It is outside the scope of this document to specify individual CCF-based protocols (e.g., events).  For example, CCF-based protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements."
+It is outside the scope of this document to specify individual CCF-based protocols (e.g., events). For example, CCF-based protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements."
 
-This document does not specify how to encode version numbers of CCF itself or CCF-based protocols.  CCF-based protocols can specify an encoding that uses CalVer, SemVer, sequence-based versioning, any other versioning, or no versioning.  Some CCF-based protocols may want to use CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) representing CCF message(s).
+This document does not specify how to encode version numbers of CCF itself or CCF-based protocols. CCF-based protocols can specify an encoding that uses CalVer, SemVer, sequence-based versioning, any other versioning, or no versioning. Some CCF-based protocols may want to use CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) representing CCF message(s).
 
 ## Introduction
 
@@ -47,7 +47,7 @@ Some requirements (such as "Deterministic CCF Encoding Requirements") are specif
 
 CCF allows efficient detection of malformed messages without creating Cadence objects. More costly validation is performed only on well-formed messages.
 
-CCF uses a subset of the Concise Binary Object Representation (CBOR) format.  CBOR is a binary data format specified by [RFC 8949](https://www.rfc-editor.org/info/std94) and designated by IETF as an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) (STD&nbsp;94). CBOR is designed to be relevant for decades and is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
+CCF uses a subset of the Concise Binary Object Representation (CBOR) format. CBOR is a binary data format specified by [RFC 8949](https://www.rfc-editor.org/info/std94) and designated by IETF as an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) (STD&nbsp;94). CBOR is designed to be relevant for decades and is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
 
 ### Objectives
 
@@ -57,7 +57,7 @@ The goal of CCF is to provide compact, efficient, and deterministic encoding of 
 
 CCF supports:
 
-- Cadence external values: CCF supports all Cadence built-in types and user-defined types (e.g., composite types).  For extensibility, CCF reserves multiple ranges of CBOR tag numbers (unassigned by IANA) for future Cadence built-in data types.
+- Cadence external values: CCF supports all Cadence built-in types and user-defined types (e.g., composite types). For extensibility, CCF reserves multiple ranges of CBOR tag numbers (unassigned by IANA) for future Cadence built-in data types.
 
 - Compact encoding:
   - CCF uses a subset of the CBOR data model with [Preferred Serialization](https://www.rfc-editor.org/rfc/rfc8949.html#name-preferred-serialization) to encode values to their shortest form.
@@ -65,15 +65,15 @@ CCF supports:
 
 - Compact communications: Detachable Cadence types allow CCF-based protocols to optionally avoid resending the same Cadence types for all messages. CCF-based protocols can cache and uniquely identify a Cadence type so it can be matched to a Cadence value during decoding.
 
-  For example, CCF encodes Cadence composite types separately from Cadence values.  Encoded values refer to their composite type by unique type ID, encoded as bytes. If the Cadence composite type (metadata) can be stored on-chain, it doesn't need to be sent with the value. Type ID can be a universal counter, hash digest, or other unique identifier specified by CCF-based protocols.
+  For example, CCF encodes Cadence composite types separately from Cadence values. Encoded values refer to their composite type by unique type ID, encoded as bytes. If the Cadence composite type (metadata) can be stored on-chain, it doesn't need to be sent with the value. Type ID can be a universal counter, hash digest, or other unique identifier specified by CCF-based protocols.
 
-- Deterministic encoding: CCF uses CBOR's Preferred Serialization to achieve deterministic encoding.  Other parts of CBOR's Core Deterministic Encoding Requirements are not needed by this specification.
+- Deterministic encoding: CCF uses CBOR's Preferred Serialization to achieve deterministic encoding. Other parts of CBOR's Core Deterministic Encoding Requirements are not needed by this specification.
 
-- Early detection of malformed data: CCF decoders can detect malformed data without having Cadence type information.  CCF decoders can detect and reject malformed data without creating Cadence objects.  If data is well-formed, CCF decoders can proceed to detect and reject invalid CCF data as described in this document.
+- Early detection of malformed data: CCF decoders can detect malformed data without having Cadence type information. CCF decoders can detect and reject malformed data without creating Cadence objects. If data is well-formed, CCF decoders can proceed to detect and reject invalid CCF data as described in this document.
 
 - Interoperability and reuse: CCF uses CBOR, so CCF codecs can use generic CBOR codecs that are well-tested and widely used by other projects.
 
-- Converting Data Between CCF and JSON: CCF uses a subset of the CBOR data model.  So the guidance in RFC 8949 on [converting data between CBOR and JSON](https://www.rfc-editor.org/rfc/rfc8949.html#name-converting-data-between-cbo) is applicable to CCF.
+- Converting Data Between CCF and JSON: CCF uses a subset of the CBOR data model. So the guidance in RFC 8949 on [converting data between CBOR and JSON](https://www.rfc-editor.org/rfc/rfc8949.html#name-converting-data-between-cbo) is applicable to CCF.
 
 
 ### Why CBOR
@@ -226,7 +226,7 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 A CCF encoding is deterministic if it satisfies the "Deterministic CCF Encoding Requirements."
 
-Encoders SHOULD emit deterministic CCF encodings.  However, some CCF-based protocols may not require deterministic CCF encodings.
+Encoders SHOULD emit deterministic CCF encodings. However, some CCF-based protocols may not require deterministic CCF encodings.
 
 CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings. For example:
 - A CCF-based protocol that prioritizes security above performance (or requires explicitly sorted fields) might want to specify that encoders MUST produce deterministic encodings of the values.
@@ -262,11 +262,11 @@ CBOR security considerations in [Section 10](https://www.rfc-editor.org/rfc/rfc8
 
 There are two types of checks for acceptable data: well-formedness and validity.
 
-CCF decoders MUST detect and reject malformed data items before checking for validity.  [Section 1.2](https://www.rfc-editor.org/rfc/rfc8949.html#section-1.2) of RFC 8949 defines "well-formed" data items.
+CCF decoders MUST detect and reject malformed data items before checking for validity. [Section 1.2](https://www.rfc-editor.org/rfc/rfc8949.html#section-1.2) of RFC 8949 defines "well-formed" data items.
 
 CCF decoders SHOULD detect and reject malformed data before creating Cadence objects and without requiring Cadence type information.
 
-Each CCF-based protocol MUST specify how to handle invalid CCF messages.  In some cases, it may be more practical for the application to check if the decoded data is acceptable.
+Each CCF-based protocol MUST specify how to handle invalid CCF messages. In some cases, it may be more practical for the application to check if the decoded data is acceptable.
 
 CCF decoders SHOULD allow CBOR limits to be specified and enforced, such as:
 - maximum number of array elements
@@ -283,17 +283,21 @@ Encoders usually don't enforce limits because it's simpler and more efficient fo
 
 ## CCF Examples
 
-Examples of JSON are in JSON-Cadence Data Interchange Format:
-- Minified JSON encoding size is used for comparisons.
-- Non-minified JSON encoding is shown for readability.
+Examples show Cadence data encoded in:
+- [JSON-Cadence Data Interchange Format](https://developers.flow.com/cadence/json-cadence-spec) (JSON-CDC)
+- CCF in fully self-describing mode
 
-Examples of CCF-encoded data are shown in hex or Extended Diagnostic Notation (EDN) for readability.
+CCF in partially self-describing mode is not shown here. CCF in partially self-describing mode can omit type definitions, so it can be significantly more compact than CCF in self-describing mode.
 
-For more information about EDN, see [Appendix G of RFC 8610 (CDDL)](https://www.rfc-editor.org/rfc/rfc8610.html#appendix-G).
+CCF encodings are shown in hex and described using Extended Diagnostic Notation (EDN). For more information about EDN, see [Appendix G](https://www.rfc-editor.org/rfc/rfc8610.html#appendix-G) of RFC 8610.
 
 ### Cadence Simple Type Value
 
-Cadence `Int` type with value `42` encoded to minified JSON is 27 bytes:
+Cadence `Int` type with value `42` encodes to:
+- 27 bytes in JSON-CDC (minified)
+- 9 bytes in CCF (fully self-describing mode)
+
+JSON-CDC encoding (not minified for readability):
 
 ```json
 {
@@ -302,19 +306,23 @@ Cadence `Int` type with value `42` encoded to minified JSON is 27 bytes:
 }
 ```
 
-CCF encoding is 9 bytes:
+CCF encoding (in hex for readability):
 
-```
-d88282d88904c2412a
-```
+`d88282d88904c2412a`
 
-It represents `130([137(4), 42])`, where:
+The CCF data item in diagnostic notation is `130([137(4), 42])`:
 - `137(4)` is the Cadence `Int`.
 - `42` is the raw value.
 
+A type definition is not needed because Cadence `Int` is a Simple Type (e.g., not a user-defined composite).
+
 ### Cadence Homogeneous Array with Simple Type Elements
 
-Cadence `[Int]` type of value `[1, 2, 3]` encoded to minified JSON is 107 bytes:
+Cadence `[Int]` type of value `[1, 2, 3]` encodes to:
+- 107 bytes in JSON-CDC (minified)
+- 18 bytes in CCF (fully self-describing mode)
+
+JSON-CDC encoding (not minified for readability):
 
 ```json
 {
@@ -336,19 +344,21 @@ Cadence `[Int]` type of value `[1, 2, 3]` encoded to minified JSON is 107 bytes:
 }
 ```
 
-CCF encoding is 18 bytes:
+CCF encoding (in hex for readability):
 
-```
-d88282d88bd8890483c24101c24102c24103
-```
+`d88282d88bd8890483c24101c24102c24103`
 
-It represents `130([139(137(4)), [1, 2, 3]])`, where:
+The CCF data item in diagnostic notation is `130([139(137(4)), [1, 2, 3]])`, where:
 - `139(137(4))` is the Cadence array of `Int`.
 - `[1, 2, 3]` is the raw value.
 
 ### Cadence Heterogeneous Array with Simple Type Elements
 
-Cadence `[AnyStruct]` type of value `[1, "a", true]` encoded to minified JSON is 112 bytes:
+Cadence `[AnyStruct]` type of value `[1, "a", true]` encodes to:
+- 112 bytes in JSON-CDC (minified)
+- 34 bytes in CCF (fully self-describing mode)
+
+JSON-CDC encoding (not minified for readability)
 
 ```json
 {
@@ -370,25 +380,27 @@ Cadence `[AnyStruct]` type of value `[1, "a", true]` encoded to minified JSON is
 }
 ```
 
-CCF encoding is 34 bytes:
+CCF encoding (in hex for readability):
 
-```
-d88282d88bd889182783d88282d88904c24101d88282d889016161d88282d88900f5
-```
+`d88282d88bd889182783d88282d88904c24101d88282d889016161d88282d88900f5`
 
-It represents `130([139(137(39)), [130([137(4), 1]), 130([137(1), "a"]), 130([137(0), true])]])`, where:
+The CCF data item in diagnostic notation is `130([139(137(39)), [130([137(4), 1]), 130([137(1), "a"]), 130([137(0), true])]])`, where:
 - `139(137(39))` is the Cadence array of `AnyStruct`.
-- `130([137(4), 1])` is the first element (`137(4)` is the Cadence `Int`, `1` is the raw value).
-- `130([137(1), "a"])` is the second element (`137(1)` is the Cadence `String`, `"a"` is the raw value).
-- `130([137(0), true]` is the third element (`137(0)` is the Cadence `Boolean`, `true` is the raw value).
+- `130([137(4), 1])` is the first element. `137(4)` is the Cadence `Int`, `1` is the raw value.
+- `130([137(1), "a"])` is the second element. `137(1)` is the Cadence `String`, `"a"` is the raw value.
+- `130([137(0), true]` is the third element. `137(0)` is the Cadence `Boolean`, `true` is the raw value.
 
 ### Cadence Homogeneous Array with Composite Type Elements
 
-This example is for CCF in fully self-describing mode (partially self-describing mode encodes smaller messages).
-
 Cadence composite types, such as struct, resource, and event, are not inlined as type information. Each encoded composite type information has a unique ID that is used to bind with a Cadence value.
 
-Cadence `[Foo]` type encoded to minified JSON is 353 bytes:
+This example uses a Cadence homogeneous array `[Foo]`. The elements have the same Cadence composite type `Foo`, which has a field named `bar` of type Cadence `Int`.
+
+Cadence `[Foo]` type encodes to:
+- 353 bytes in JSON-CDC (minified)
+- 47 bytes in CCF (fully self-describing mode)
+
+JSON-CDC encoding (not minified for readability):
 
 ```json
 {
@@ -443,30 +455,34 @@ Cadence `[Foo]` type encoded to minified JSON is 353 bytes:
 }
 ```
 
-CCF encoding is 47 bytes (in fully self-describing mode):
+CCF encoding (in hex for readability):
 
-```
-d8818281d8a183406a532e746573742e466f6f818263626172d8890482d88bd888408381c2410181c2410281c24103
-```
+`d8818281d8a183406a532e746573742e466f6f818263626172d8890482d88bd888408381c2410181c2410281c24103`
 
-It represents `129([[161([h'', "S.test.Foo", [["bar", 137(4)]]])], [139(136(h'')), [[1], [2], [3]]]])`, which contains type and value.
+In fully self-describing mode, a CCF data item can contain the value and type definition(s) used by the value.
 
-Type data item represents `161([h'', "S.test.Foo", [["bar", 137(4)]]])` , which defines a resource type:
+The CCF data item in diagnostic notation is:
+
+`129([[161([h'', "S.test.Foo", [["bar", 137(4)]]])], [139(136(h'')), [[1], [2], [3]]]])`
+
+Within the CCF data item, the type is `161([h'', "S.test.Foo", [["bar", 137(4)]]])` which defines a resource type:
 - `h''` is CCF type ID `0`. This ID is used inside the value data item to bind the type with the raw value.
 - `"S.test.Foo"` is the Cadence type ID.
 - `[["bar", 137(4)]]` is the field definition of the `"bar"` field of Cadence `Int`.
 
-Value data item represents `[139(136(h'')), [[1], [2], [3]]]]`, where:
+Within the CCF data item, the value is `[139(136(h'')), [[1], [2], [3]]]]`, where:
 - `139(136(h''))` is the Cadence array of the type identified by ID `0`.
 - `[[1], [2], [3]]]` is the array of raw field data of the `Foo` resource.
 
 ### Cadence Homogeneous Array with Composite Type Elements (One Field Type Is Abstract)
 
-This example is for CCF in fully self-describing mode (partially self-describing mode encodes smaller messages).
+This example uses a Cadence homogeneous array `[Foo]`. The elements have the same Cadence composite type. The `baz` field of the composite is an abstract type.
 
-Composite field `baz` is abstract type.
+This example encodes to:
+- 508 bytes in JSON-CDC (minified)
+-  80 bytes in CCF (fully self-describing mode)
 
-Cadence `[Foo]` type encoded to minified JSON is 508 bytes:
+JSON-CDC encoding (not minified for readability):
 
 ```json
 {
@@ -542,21 +558,23 @@ Cadence `[Foo]` type encoded to minified JSON is 508 bytes:
 }
 ```
 
-CCF encoding is 80 bytes (in fully self-describing mode):
+CCF encoding (in fully self-describing mode):
 
-```
-d8818281d8a183406a532e746573742e466f6f828263626172d88904826362617ad889182782d88bd888408382c24101d88282d88904c2410182c24102d88282d88901616182c24103d88282d88900f5
-```
+`d8818281d8a183406a532e746573742e466f6f828263626172d88904826362617ad889182782d88bd888408382c24101d88282d88904c2410182c24102d88282d88901616182c24103d88282d88900f5`
 
-It represents `129([[161([h'', "S.test.Foo", [["bar", 137(4)], ["baz", 137(39)]]])], [139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137(1), "a"])], [3, 130([137(0), true])]]]])`, which contains type and value.
+In fully self-describing mode, a CCF data item can contain the value and type definition(s) used by the value.
 
-Type data item represents `161([h'', "S.test.Foo", [["bar", 137(4)], ["baz", 137(39)]]])` , which defines a resource type:
+The CCF data item in diagnostic notation is:
+
+`129([[161([h'', "S.test.Foo", [["bar", 137(4)], ["baz", 137(39)]]])], [139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137(1), "a"])], [3, 130([137(0), true])]]]])`
+
+Within the CCF data item, the type is `161([h'', "S.test.Foo", [["bar", 137(4)], ["baz", 137(39)]]])` , which defines a resource type:
 - `h''` is CCF type ID `0`. This ID is used inside the value data item to bind the type with the raw value.
 - `"S.test.Foo"` is the Cadence type ID.
 - `["bar", 137(4)]` is the first field: `"bar"` field of Cadence `Int`.
 - `["baz", 137(39)]` is the second field: `"baz"` field of Cadence `AnyStruct`.
 
-Value data item represents `[139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137(1), "a"])], [3, 130([137(0), true])]]]`, where:
+Within the CCF data item, the value is `[139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137(1), "a"])], [3, 130([137(0), true])]]]`, where:
 - `139(136(h''))` is the Cadence array of the type identified by ID `0`.
 - `[1, 130([137(4), 1])]` is the raw field data of the first resource.
 - `[2, 130([137(1), "a"])]` is the raw field data of the second resource.
@@ -564,9 +582,11 @@ Value data item represents `[139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137
 
 ### `FeesDeducted` Event
 
-This example is for CCF in fully self-describing mode partially self-describing mode encodes smaller messages).
+Cadence `FeesDeducted` event encodes to:
+- 298 bytes in JSON-CDC (minified):
+- 118 bytes in CCF (fully self-describing mode)
 
-Cadence `FeesDeducted` event encoded to minified JSON is 298 bytes:
+JSON-CDC encoding (not minified for readability):
 
 ```json
 {
@@ -600,20 +620,22 @@ Cadence `FeesDeducted` event encoded to minified JSON is 298 bytes:
 }
 ```
 
-CCF encoding is 118 bytes (in fully self-describing mode):
+CCF encoding (in hex for readability):
 
-```
-d8818281d8a283407828412e663931396565373734343762373439372e466c6f77466565732e466565734465647563746564838266616d6f756e74d88917826f657865637574696f6e4566666f7274d88917826f696e636c7573696f6e4566666f7274d8891782d8884083190b9919023f1a05f5e100
-```
+`d8818281d8a283407828412e663931396565373734343762373439372e466c6f77466565732e466565734465647563746564838266616d6f756e74d88917826f657865637574696f6e4566666f7274d88917826f696e636c7573696f6e4566666f7274d8891782d8884083190b9919023f1a05f5e100`
 
-It represents `129([[162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])], [136(h''), [2969, 575, 100000000]]])`, which contains type and value.
+The CCF data item in diagnostic notation is:
 
-Type data item represents `162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])` , which defines an event type:
+`129([[162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])], [136(h''), [2969, 575, 100000000]]])`.
+
+CCF data items contain type definition and value in fully self-describing mode.
+
+Within the CCF data item, the type is `162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])`:
 - `h''` is CCF type ID `0`. This ID is used inside the value data item to bind the type with the raw value.
 - `"A.f919ee77447b7497.FlowFees.FeesDeducted"` is the Cadence type ID.
 - `[["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]` is field definition with 3 fields: `"amount"` field of Cadence `UFix64`, `"inclusionEffort"` field of Cadence `UFix64`, and `"executionEffort"` field of Cadence `UFix64`. Fields are sorted by field name.
 
-Value data item represents `[136(h''), [2969, 575, 100000000]]`, where:
+Within the CCF data item, the value is  `[136(h''), [2969, 575, 100000000]]`, where:
 - `136(h'')` is the type identified by ID `0`.
 - `[2969, 575, 100000000]` is `FeesDeducted` event raw field data.
 
@@ -631,7 +653,9 @@ Cadence data is encoded depending on its type. For example, Cadence `UInt8` is e
 
 ### Cadence Types and Type Values
 
-Cadence types and Cadence type values (run-time types) are encoded differently. They contain different data because they are used differently.
+Cadence has types and values. A "type value" is a value that represents a type.
+
+Cadence types and Cadence type values are encoded differently. They contain different data because they are used differently.
 
 Cadence types are used to decode Cadence data, so they only contain information needed for decoding. For example, field information of a composite type is needed to decode the composite value. However, field information of an interface type isn't needed to decode values implementing the interface type.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -230,9 +230,11 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 A CCF encoding is deterministic if it satisfies the "Deterministic CCF Encoding Requirements."
 
-Encoders SHOULD emit deterministic CCF encodings. CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings. For example:
-- a CCF-based protocol for encoding transaction arguments might want to specify that encoders MUST produce deterministic encodings of the values.
-- a CCF-based protocol for encoding unsorted fields might want to specify that encoders are not required to produce deterministic encodings of the values (if compatibility with legacy systems is a higher priority than "Deterministic CCF Encoding Requirements"). 
+Encoders SHOULD emit deterministic CCF encodings.  However, some CCF-based protocols may not require deterministic CCF encodings.
+
+CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings. For example:
+- A CCF-based protocol for encoding transaction arguments might want to specify that encoders MUST produce deterministic encodings of the values.
+- A CCF-based protocol for encoding unsorted fields might want to specify that encoders are not required to produce deterministic encodings of the values (if compatibility with legacy systems is a higher priority than "Deterministic CCF Encoding Requirements"). 
 
 Decoders SHOULD check CCF encodings to determine whether they are deterministic encodings. CCF-based protocols MUST specify when decoders are required to check for deterministic encodings and how to handle nondeterministic encodings.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,7 +2,7 @@
 
 Author: Faye Amacker  
 Version: 1.0.0  
-Date: October 22, 2024  
+Date: January 26, 2025  
 
 ## Abstract
 
@@ -16,7 +16,7 @@ CCF obsoletes [JSON-Cadence Data Interchange Format](https://developers.flow.com
 
 ## Copyright Notice
 
-Copyright © 2022-2024 Flow Foundation and the persons identified as the document authors.
+Copyright © 2022-2025 Flow Foundation and the persons identified as the document authors.
 
 This document is licensed under the terms of the Apache License, Version 2.0. See [LICENSE](LICENSE) for more information.
 
@@ -115,14 +115,14 @@ CBOR data can be exchanged between standards compliant CBOR codecs implemented i
 
 CBOR-based formats and protocols can use existing CBOR codecs. For example, [CCF codec](https://github.com/onflow/cadence/tree/master/encoding/ccf) in Cadence uses [fxamacker/cbor](https://github.com/fxamacker/cbor):
   - `fxamacker/cbor` was designed with security in mind and passed multiple security assessments in 2022. A [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) produced by NCC Group for Microsoft Corporation includes parts of fxamacker/cbor.
-  - `fxamacker/cbor` is used in projects by Arm Ltd., Cisco, Dapper Labs, EdgeX&nbsp;Foundry, Fraunhofer&#8209;AISEC, Linux&nbsp;Foundation, Microsoft, Mozilla, Tailscale, Teleport, [and&nbsp;others](https://github.com/fxamacker/cbor#who-uses-fxamackercbor). Notably, it was already [used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
+  - `fxamacker/cbor` is used in projects by Arm Ltd., Cisco, EdgeX&nbsp;Foundry, Flow Foundation, Fraunhofer&#8209;AISEC, IBM, Kubernetes, Linux&nbsp;Foundation, Microsoft, Mozilla, Tailscale, Teleport, [and&nbsp;others](https://github.com/fxamacker/cbor#who-uses-fxamackercbor). Notably, it was already [used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
   - `fxamacker/cbor` is maintained by the author of this document.
 
 CBOR codecs are available in various programming languages. Examples include:
 
-- __.NET Languages__: Microsoft maintains [System.Formats.Cbor namespace](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor), which is the CBOR codec in .Net Platform Extensions.
+- __.NET Languages__: Microsoft maintains [System.Formats.Cbor](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor), the CBOR codec in .Net Platform Extensions.
 - __C/C++__: Intel maintains [TinyCBOR](https://github.com/intel/tinycbor), a CBOR codec optimized for very fast operation with very small footprint.
-- __Javascript__: [hildjj/node-cbor](https://github.com/hildjj/node-cbor) and its successor [hildji/cbor2](https://github.com/hildjj/cbor2) are maintained by Joe Hildebrand (former VP of Engineering at Mozilla).
+- __Javascript__: Joe Hildebrand (former VP of Engineering at Mozilla) maintains [hildji/cbor2](https://github.com/hildjj/cbor2).
 
 Projects implementing a CCF codec should evaluate more than one CBOR codec for standards compliance, security, and other factors.
 
@@ -239,7 +239,7 @@ A CCF encoding is deterministic if it satisfies the "Deterministic CCF Encoding 
 
 Encoders SHOULD emit CCF encodings that are deterministic. CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings. For example:
 - a CCF-based protocol for encoding transaction arguments might want to specify that encoders MUST produce deterministic encodings of the values.
-- a CCF-based protocol for encoding script results might want to specify that encoders are not required to produce deterministic encodings of the values (if results are sent to clients that don't care about the values being deterministically encoded). 
+- a CCF-based protocol for encoding unsorted fields might want to specify that encoders are not required to produce deterministic encodings of the values (if compatibility with legacy systems is higher priority than "Deterministic CCF Encoding Requirements"). 
 
 Decoders SHOULD check CCF encodings to determine whether they are deterministic encodings. CCF-based protocols MUST specify when decoders are required to check for deterministic encodings and how to handle nondeterministic encodings.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -265,8 +265,8 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
 CBOR security considerations in [Section 10 of RFC 8949 (CBOR)](https://www.rfc-editor.org/rfc/rfc8949.html#name-security-considerations) apply to CCF.
 
 There are two types of checks for acceptable data:
-- Checks for well-formedness
-- Checks for validity
+- well-formedness
+- validity
 
 CBOR defines data [well-formedness](https://www.rfc-editor.org/rfc/rfc8949.html#name-well-formedness-errors-and-), and a CBOR decoder MUST detect and reject malformed data before checking for validity.
 
@@ -277,9 +277,9 @@ CCF decoders SHOULD detect and reject malformed data before creating Cadence obj
 CCF decoders can handle invalid CCF messages as required by each CCF-based protocol. In some cases, it may be more practical for the application to check if the decoded data is acceptable.
 
 CCF decoders SHOULD allow CBOR limits to be specified and enforced, such as:
-- Maximum number of array elements
-- Maximum number of map pairs
-- Maximum nested levels
+- maximum number of array elements
+- maximum number of map pairs
+- maximum nested levels
 
 For example, the maximum number of array elements would forbid any single array in a CCF message from exceeding that many elements.
 


### PR DESCRIPTION
This PR updates CCF Specs to version 1.0 and matches the deployed version of CCF Codec.

Primarily, this PR adds new Cadence types and other updates to match changes in Cadence:
- Update for https://github.com/onflow/cadence/pull/2581
- Update for https://github.com/onflow/cadence/pull/3107
- Update for https://github.com/onflow/cadence/pull/3131
- Update for https://github.com/onflow/cadence/pull/3139

Other changes in this PR:
- Update copyright for Flow Foundation.
- Added "Version: 1.0.0" and removed "Revision".
- Removed "Status: RC3" and "Status of this Document".
- Update "Scope" to highlight some scope-related items earlier:
  - Some requirements are explicitly defined as optional.
  - CCF-based formats or protocols MUST specify when optional requirements are used.
  - "Deterministic CCF Encoding Requirements" is optional so individual formats and protocols  MUST specify when to use it (as previously stated deeper in this document).
- Update "Scope" to explicitly mention how to encode version numbers is outside the scope of this document.  CCF-based formats and protocols are free to specify if version numbers are encoded and how to encode them.
- Update "CCF Examples" section to make it easier to read and understand.
- Mention some items that might not be known to all readers.
- Improve grammar and fix typos.

> [!NOTE]
> Scope of specs hasn't changed because the added text only highlights what is stated deeper inside the document.
